### PR TITLE
Add ca-certificates to stage-packages

### DIFF
--- a/.github/workflows/test-rock.yaml
+++ b/.github/workflows/test-rock.yaml
@@ -1,0 +1,25 @@
+name: Pack ROCK
+
+on:
+  pull_request: {}
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup LXD
+      uses: canonical/setup-lxd@v0.1.1
+      with:
+        channel: latest/stable
+
+    - name: Install dependencies
+      run: |
+        sudo snap install --classic --channel edge rockcraft
+
+    - name: Build ROCK
+      id: build_rock
+      run: |
+        rockcraft pack --verbose

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @abuelodelanada @dstathis @lucabello @pietropasotti @sed-i @simskij

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -25,7 +25,7 @@ parts:
     plugin: npm
     source-type: git
     source-depth: 1
-    source-tag: "v2.9.6"
+    source-tag: "v2.10.2"
     source: https://github.com/traefik/traefik
     npm-node-version: 14.16
     build-packages:
@@ -61,7 +61,7 @@ parts:
       - GO111MODULE: "on"
       - CGO_ENABLED: "0"
       - GOGC: "off"
-      - TRAEFIK_VERSION: "2.9.6"
+      - TRAEFIK_VERSION: "2.10.2"
     override-build: |
       CODENAME=$(yq e '.blocks[] | select(.name=="Release").task.env_vars[] | select(.name=="CODENAME").value' ./.semaphore/semaphore.yml) && \
       mkdir -p dist && \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -79,6 +79,8 @@ parts:
       traefik: bin/traefik
     stage:
       - bin/traefik
+    stage-packages:
+      - ca-certificates
   non-root-user:
     plugin: nil
     after: [default-config]


### PR DESCRIPTION
This is needed for the `update-ca-certificates` machinery.

Failing traefik itest: https://github.com/canonical/traefik-k8s-operator/actions/runs/5824074775/job/15792456216#step:5:1075

This change is needed for the following to work:
- https://github.com/canonical/traefik-k8s-operator/pull/204