### PR TITLE
add new versions and fix certificates

### DIFF
--- a/2.10.4/rockcraft.yaml
+++ b/2.10.4/rockcraft.yaml
@@ -85,7 +85,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
 
   non-root-user:
     plugin: nil

--- a/2.10.5/rockcraft.yaml
+++ b/2.10.5/rockcraft.yaml
@@ -84,7 +84,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   non-root-user:
     plugin: nil
     after: [default-config]

--- a/2.10.7/rockcraft.yaml
+++ b/2.10.7/rockcraft.yaml
@@ -84,7 +84,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   non-root-user:
     plugin: nil
     after: [default-config]

--- a/2.11.0/files/traefik.yaml
+++ b/2.11.0/files/traefik.yaml
@@ -1,0 +1,13 @@
+log:
+  level: DEBUG
+
+providers:
+  file:
+    directory: /etc/traefik
+    watch: true
+
+entryPoints:
+  web:
+    address: ":8080"
+  websecure:
+    address: ":8081"

--- a/2.11.0/rockcraft.yaml
+++ b/2.11.0/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: traefik
 summary: Traefik in a ROCK.
 description: "Traefik is the a cloud-native application networking stack."
-version: "2.10.6"
+version: "2.11.0"
 base: ubuntu@22.04
 license: Apache-2.0
 # sources:
@@ -25,7 +25,7 @@ parts:
     plugin: npm
     source-type: git
     source-depth: 1
-    source-tag: "v2.10.6"
+    source-tag: "v2.11.0"
     source: https://github.com/traefik/traefik
     npm-node-version: 14.16
     build-packages:
@@ -52,16 +52,16 @@ parts:
     plugin: go
     source-type: git
     source-depth: 1
-    source-tag: "v2.10.6"
+    source-tag: "v2.11.0"
     source: https://github.com/traefik/traefik
     build-snaps:
       - yq
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - GO111MODULE: "on"
       - CGO_ENABLED: "0"
       - GOGC: "off"
-      - TRAEFIK_VERSION: "2.10.6"
+      - TRAEFIK_VERSION: v2.11.0
     override-build: |
       CODENAME=$(yq e '.blocks[] | select(.name=="Release").task.env_vars[] | select(.name=="CODENAME").value' ./.semaphore/semaphore.yml) && \
       mkdir -p dist && \
@@ -105,5 +105,4 @@ parts:
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/
       (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query
-
 # TODO verification steps and testing framework


### PR DESCRIPTION
## Issue
Currently, the `ca-certificates` package is added to the rock, but it's missing the default certificates in `/etc/ssl/certs`.

This happens not because we don't stage them, but because `stage-packages: [ca-certificates]` doesn't run the maintainer scripts that would populate `/etc/ssl/certs`, so that folder stays empty.

## Solution
The solution to this is to change `stage-packages:` to `overlay-packages` in the `ca-certs` part, because that also runs the maintainer scripts and correctly populates the `/ets/ssl/certs` folder.

---

Also adding some versions from pending PRs :)

## Testing Instructions

You can test it yourself by simply running the rock and checking the certs are there via `ls /etc/ssl/certs`.

```bash
root@8f0199aebc08:/# which update-ca-certificates
/usr/sbin/update-ca-certificates
root@8f0199aebc08:/# ll /etc/ssl/certs/
total 604
```