### PR TITLE
feat: add goss checks and new version

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -3,7 +3,7 @@ name: Update rock
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0,4,8,12,16,20 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -23,3 +23,4 @@ jobs:
         ## traefik environment variable
         yq -i 'del(.parts.traefik.build-environment.[] | select (.TRAEFIK_VERSION))' $rockcraft_yaml
         tag="\$source_tag" yq -i '.parts.traefik.build-environment += [{"TRAEFIK_VERSION": strenv(tag)}]' $rockcraft_yaml
+    secrets: inherit

--- a/3.2.2/files/traefik.yaml
+++ b/3.2.2/files/traefik.yaml
@@ -1,0 +1,13 @@
+log:
+  level: DEBUG
+
+providers:
+  file:
+    directory: /etc/traefik
+    watch: true
+
+entryPoints:
+  web:
+    address: ":8080"
+  websecure:
+    address: ":8081"

--- a/3.2.2/rockcraft.yaml
+++ b/3.2.2/rockcraft.yaml
@@ -20,6 +20,7 @@ services:
     startup: enabled
 platforms:
   amd64:
+  arm64:
 parts:
   traefik-frontend:
     plugin: npm
@@ -27,7 +28,8 @@ parts:
     source-depth: 1
     source-tag: "v3.2.2"
     source: https://github.com/traefik/traefik
-    npm-node-version: 14.16
+    npm-node-version: "14.16"
+    npm-include-node: true
     build-packages:
       - nodejs
       - npm

--- a/3.2.2/rockcraft.yaml
+++ b/3.2.2/rockcraft.yaml
@@ -1,0 +1,108 @@
+name: traefik
+summary: Traefik in a rock.
+description: "Traefik is the a cloud-native application networking stack."
+version: "3.2.2"
+base: ubuntu@24.04
+license: Apache-2.0
+# sources:
+# jnsgruk's traefik dockerfile https://github.com/jnsgruk/traefik-oci-image/blob/main/Dockerfile
+# upstream traefik makefile https://github.com/traefik/traefik/blob/84a081054688349fa4e2513599e3bf2395331492/Makefile
+
+# /
+# ├── bin
+# │   └── traefik
+# └── etc
+#     └── traefik.yaml
+services:
+  traefik:
+    command: /bin/traefik
+    override: replace
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  traefik-frontend:
+    plugin: npm
+    source-type: git
+    source-depth: 1
+    source-tag: "v3.2.2"
+    source: https://github.com/traefik/traefik
+    npm-node-version: 14.16
+    build-packages:
+      - nodejs
+      - npm
+    override-build: |
+      npm install -g yarn && \
+      cd ./webui && \
+      # added --legacy-peer-deps to avoid dependency resolution errors with mocha (testing)
+      npm install --legacy-peer-deps && \
+      # Build the bundle as per:
+      # https://github.com/traefik/traefik/blob/84a081054688349fa4e2513599e3bf2395331492/Makefile#L66
+      npm run build:nc && \
+      # cleanup
+      rm -rf node_modules
+  default-config:
+    plugin: dump
+    source: files
+    organize:
+      traefik.yaml: etc/traefik/traefik.yaml
+    stage:
+      - etc/traefik/traefik.yaml
+  traefik:
+    plugin: go
+    source-type: git
+    source-depth: 1
+    source-tag: "v3.2.2"
+    source: https://github.com/traefik/traefik
+    build-snaps:
+      - yq
+      - go/1.23/stable
+    build-environment:
+      - GO111MODULE: "on"
+      - CGO_ENABLED: "0"
+      - GOGC: "off"
+      - TRAEFIK_VERSION: v3.2.2
+    override-build: |
+      CODENAME=$(yq e '.blocks[] | select(.name=="Release").task.env_vars[] | select(.name=="CODENAME").value' ./.semaphore/semaphore.yml) && \
+      mkdir -p dist && \
+      # Required to merge non-code components into the final binary such as the web dashboard/UI
+      go generate && \
+      # Build Traefik per https://github.com/traefik/traefik/raw/v2.6.1/script/binary
+      go build -ldflags "-s -w \
+        -X github.com/traefik/traefik/v2/pkg/version.Version=$TRAEFIK_VERSION \
+        -X github.com/traefik/traefik/v2/pkg/version.Codename=$CODENAME \
+        -X github.com/traefik/traefik/v2/pkg/version.BuildDate=$(date -u '+%Y-%m-%d_%I:%M:%S%p')" \
+        -a -installsuffix nocgo -o $CRAFT_PART_INSTALL/traefik ./cmd/traefik
+    after:
+      - traefik-frontend
+    organize:
+      traefik: bin/traefik
+    stage:
+      - bin/traefik
+    stage-packages:
+      - ca-certificates
+  # We moved this here because: https://github.com/canonical/rockcraft/issues/343
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  non-root-user:
+    plugin: nil
+    after: [default-config]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1000 traefik
+      useradd -R $CRAFT_OVERLAY -M -r -g traefik -u 1000 traefik
+    override-prime: |
+      craftctl default
+      chown -R 1000:1000 etc/traefik
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - traefik
+      - traefik-frontend
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query
+# TODO verification steps and testing framework

--- a/README.md
+++ b/README.md
@@ -9,8 +9,19 @@ This repository holds all the necessary files to build rocks for the upstream ve
 
 The rocks on this repository are built with [OCI Factory](https://github.com/canonical/oci-factory/), which also takes care of periodically rebuilding the images.
 
+**How do I interact with this repo?** This repo uses [`just`](https://github.com/casey/just) to easily run some commands:
+```
+∮ just
+Available recipes:
+    clean version               # `rockcraft clean` for a specific version
+    pack version                # Pack a rock of a specific version
+    run version=latest_version  # Run a rock and open a shell into it with `kgoss`
+    test version=latest_version # Test the rock with `kgoss`
+```
+
 Automation takes care of:
 * validating PRs, by simply trying to build the rock;
 * pulling upstream releases, creating a PR with the necessary files to be manually reviewed;
+* on PRs, validate the added (or modified) rocks by running `kgoss`;
 * releasing to GHCR at [ghcr.io/canonical/traefik:dev](https://ghcr.io/canonical/traefik:dev), when merging to main, for development purposes.
 

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,0 +1,7 @@
+process:
+  alertmanager:
+    running: true
+http:
+  healthy:
+    status: 200
+    url: http://localhost:9093/-/healthy

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,7 +1,7 @@
 process:
-  alertmanager:
+  traefik:
     running: true
 http:
-  healthy:
+  version:
     status: 200
-    url: http://localhost:9093/-/healthy
+    url: http://localhost/version

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+set quiet # Recipes are silent by default
+set export # Just variables are exported to environment variables
+
+rock_name := `echo ${PWD##*/} | sed 's/-rock//'`
+latest_version := `find . -maxdepth 1 -type d | sort -V | tail -n1 | sed 's@./@@'`
+
+[private]
+default:
+  just --list
+
+# Push an OCI image to a local registry
+[private]
+push-to-registry version:
+  echo "Pushing $rock_name $version to local registry"
+  rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+    "oci-archive:${version}/${rock_name}_${version}_amd64.rock" \
+    "docker://localhost:32000/${rock_name}-dev:${version}"
+
+# Pack a rock of a specific version
+pack version:
+  cd "$version" && rockcraft pack
+
+# `rockcraft clean` for a specific version
+clean version:
+  cd "$version" && rockcraft clean
+
+# Run a rock and open a shell into it with `kgoss`
+run version=latest_version: (push-to-registry version)
+  kgoss edit -i localhost:32000/${rock_name}-dev:${version}
+
+# Test the rock with `kgoss`
+test version=latest_version: (push-to-registry version)
+  GOSS_OPTS="--retry-timeout 60s" kgoss run -i localhost:32000/${rock_name}-dev:${version}


### PR DESCRIPTION
Rocks aren't packing at all. We need to fix `3.2.2` (being added in this PR) so that it packs correctly and passes the checks from `just test 3.2.2`.

## Resolution plan

1. Try to fix the `rockcraft.yaml` for `3.2.2`
2. `just pack 3.2.2`
3. `just test 3.2.2`

If the rock is running but the Goss checks are failing:
1. Figure out if the rock is running correctly by:
  - `just run 3.2.2`
  - Check `pebble services` and `curl` the `http://localhost/metrics` or whatever endpoint to make sure things are working
  - If it's not, go back to fix the `rockcraft.yaml`, otherwise move to (2)
2. Adjust the `goss.yaml` to make sure the checks are correct