### PR TITLE
chores: Add more architecture to 2.11.46

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -32,10 +32,21 @@ jobs:
         run: ./scripts/extract-versions.sh ${{ steps.changed-files.outputs.all_changed_files }}
 
   build-and-test:
-    name: Pack and test rocks
-    runs-on: ubuntu-24.04
+    name: Pack and test rocks on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runner-labels }}
     needs: [detect-changes]
     if: needs.detect-changes.outputs.versions != ''
+    strategy:
+      fail-fast: true
+      matrix:
+        # Define 'platform' as an object containing both metadata and labels
+        platform:
+          - name: Ubuntu amd64 24.04
+            runner-labels: [ubuntu-24.04]
+          - name: Ubuntu arm64 24.04
+            runner-labels: [ubuntu-24.04-arm]
+          - name: Ubuntu s390x 24.04
+            runner-labels: [self-hosted-linux-s390x-noble-medium]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -31,6 +31,19 @@ jobs:
         id: changed-versions
         run: ./scripts/extract-versions.sh ${{ steps.changed-files.outputs.all_changed_files }}
 
+      - name: Format versions as JSON array
+        id: format-json
+        env:
+          RAW_VERSIONS: ${{ steps.changed-versions.outputs.versions }}
+        run: |
+          if [ -z "$RAW_VERSIONS" ]; then
+            echo "versions=[]" >> "$GITHUB_OUTPUT"
+          else
+            # Safely converts space-separated versions into a strict JSON array
+            JSON_ARRAY=$(echo "$RAW_VERSIONS" | xargs jq -n -c '$ARGS.positional' --args)
+            echo "versions=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-test:
     name: Pack and test ${{ matrix.version }} on ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.runner-labels }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -58,7 +58,53 @@ jobs:
         run: sudo snap install rockcraft --classic --channel=latest/candidate
 
       - name: Install goss
-        run: curl -fsSL https://goss.rocks/install | sh
+      #   run: curl -fsSL https://goss.rocks/install | sh
+        run: |
+          uname -a
+          LATEST_URL="https://github.com/goss-org/goss/releases/latest"
+          LATEST_EFFECTIVE=$(curl -s -L -o /dev/null ${LATEST_URL} -w '%{url_effective}')
+          LATEST=${LATEST_EFFECTIVE##*/}
+          
+          DGOSS_VER=$GOSS_VER
+          
+          if [ -z "$GOSS_VER" ]; then
+              GOSS_VER=${GOSS_VER:-$LATEST}
+              DGOSS_VER='master'
+          fi
+          if [ -z "$GOSS_VER" ]; then
+              echo "ERROR: Could not automatically detect latest version, set GOSS_VER env var and re-run"
+              exit 1
+          fi
+          GOSS_DST=${GOSS_DST:-/usr/local/bin}
+          INSTALL_LOC="${GOSS_DST%/}/goss"
+          DGOSS_INSTALL_LOC="${GOSS_DST%/}/dgoss"
+          touch "$INSTALL_LOC" || { echo "ERROR: Cannot write to $GOSS_DST set GOSS_DST elsewhere or use sudo"; exit 1; }
+          
+          arch=""
+          if [ "$(uname -m)" = "x86_64" ]; then
+              arch="amd64"
+          elif [ "$(uname -m)" = "aarch32" ]; then
+              arch="arm"
+          elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+              arch="arm64"
+          else
+              arch="386"
+          fi
+          
+          url="https://github.com/goss-org/goss/releases/download/$GOSS_VER/goss-linux-$arch"
+          
+          echo "Downloading $url"
+          curl -L "$url" -o "$INSTALL_LOC"
+          chmod +rx "$INSTALL_LOC"
+          echo "Goss $GOSS_VER has been installed to $INSTALL_LOC"
+          echo "goss --version"
+          "$INSTALL_LOC" --version
+          
+          dgoss_url="https://raw.githubusercontent.com/goss-org/goss/$DGOSS_VER/extras/dgoss/dgoss"
+          echo "Downloading $dgoss_url"
+          curl -L "$dgoss_url" -o "$DGOSS_INSTALL_LOC"
+          chmod +rx "$DGOSS_INSTALL_LOC"
+          echo "dgoss $DGOSS_VER has been installed to $DGOSS_INSTALL_LOC"
 
       - name: Pack and test rocks
         run: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,6 +51,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up tmate session
+        if: runner.debug == 1
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+          timeout-minutes: 60
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Install yq
         run: sudo snap install yq
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
 
@@ -152,6 +153,6 @@ jobs:
 
       - name: Pack and test rocks
         if: steps.check-arch.outputs.supported == 'true'
-        run:
+        run: |
           GOSS_FILES_PATH="$GITHUB_WORKSPACE" \
             ./scripts/pack-and-test.sh ${{ matrix.version }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Determine modified rocks
     runs-on: ubuntu-24.04
     outputs:
-      versions: ${{ steps.changed-versions.outputs.versions }}
+      versions: ${{ steps.format-json.outputs.versions }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,12 +51,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up tmate session
-        if: runner.debug == 1
-        uses: mxschmitt/action-tmate@v3
+      - name: Set up tmate session (self-hosted)
+        if: runner.debug == 1 && runner.environment == 'self-hosted'
+        uses: canonical/action-tmate@main
         with:
           detached: true
           timeout-minutes: 60
+
+      - name: Set up tmate session (GitHub-hosted)
+        if: runner.debug == 1 && runner.environment == 'github-hosted'
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -103,53 +103,7 @@ jobs:
 
       - name: Install goss
         if: steps.check-arch.outputs.supported == 'true'
-        run: |
-          # this is the same script as in https://goss.rocks/install
-          # with the arch updated to "$(uname -m)" when it is not arm/arm64/amd64.
-          LATEST_URL="https://github.com/goss-org/goss/releases/latest"
-          LATEST_EFFECTIVE=$(curl -s -L -o /dev/null ${LATEST_URL} -w '%{url_effective}')
-          LATEST=${LATEST_EFFECTIVE##*/}
-          
-          DGOSS_VER=$GOSS_VER
-          
-          if [ -z "$GOSS_VER" ]; then
-              GOSS_VER=${GOSS_VER:-$LATEST}
-              DGOSS_VER='master'
-          fi
-          if [ -z "$GOSS_VER" ]; then
-              echo "ERROR: Could not automatically detect latest version, set GOSS_VER env var and re-run"
-              exit 1
-          fi
-          GOSS_DST=${GOSS_DST:-/usr/local/bin}
-          INSTALL_LOC="${GOSS_DST%/}/goss"
-          DGOSS_INSTALL_LOC="${GOSS_DST%/}/dgoss"
-          touch "$INSTALL_LOC" || { echo "ERROR: Cannot write to $GOSS_DST set GOSS_DST elsewhere or use sudo"; exit 1; }
-          
-          arch=""
-          if [ "$(uname -m)" = "x86_64" ]; then
-              arch="amd64"
-          elif [ "$(uname -m)" = "aarch32" ]; then
-              arch="arm"
-          elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
-              arch="arm64"
-          else
-              arch="$(uname -m)"
-          fi
-          
-          url="https://github.com/goss-org/goss/releases/download/$GOSS_VER/goss-linux-$arch"
-          
-          echo "Downloading $url"
-          curl -L "$url" -o "$INSTALL_LOC"
-          chmod +rx "$INSTALL_LOC"
-          echo "Goss $GOSS_VER has been installed to $INSTALL_LOC"
-          echo "goss --version"
-          "$INSTALL_LOC" --version
-          
-          dgoss_url="https://raw.githubusercontent.com/goss-org/goss/$DGOSS_VER/extras/dgoss/dgoss"
-          echo "Downloading $dgoss_url"
-          curl -L "$dgoss_url" -o "$DGOSS_INSTALL_LOC"
-          chmod +rx "$DGOSS_INSTALL_LOC"
-          echo "dgoss $DGOSS_VER has been installed to $DGOSS_INSTALL_LOC"
+        run: ./scripts/install-goss.sh
 
       - name: Pack and test rocks
         if: steps.check-arch.outputs.supported == 'true'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -88,7 +88,7 @@ jobs:
           elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
               arch="arm64"
           else
-              arch="386"
+              arch="$(uname -m)"
           fi
           
           url="https://github.com/goss-org/goss/releases/download/$GOSS_VER/goss-linux-$arch"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -32,20 +32,23 @@ jobs:
         run: ./scripts/extract-versions.sh ${{ steps.changed-files.outputs.all_changed_files }}
 
   build-and-test:
-    name: Pack and test rocks on ${{ matrix.platform.name }}
+    name: Pack and test ${{ matrix.version }} on ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.runner-labels }}
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.versions != ''
+    if: needs.detect-changes.outputs.versions != '' && needs.detect-changes.outputs.versions != '[]'
     strategy:
       fail-fast: true
       matrix:
-        # Define 'platform' as an object containing both metadata and labels
+        version: ${{ fromJson(needs.detect-changes.outputs.versions) }}
         platform:
-          - name: Ubuntu amd64 24.04
+          - name: amd64
+            arch: amd64
             runner-labels: [ubuntu-24.04]
-          - name: Ubuntu arm64 24.04
+          - name: arm64
+            arch: arm64
             runner-labels: [ubuntu-24.04-arm]
-          - name: Ubuntu s390x 24.04
+          - name: s390x
+            arch: s390x
             runner-labels: [self-hosted-linux-s390x-noble-medium]
     steps:
       - name: Checkout repository
@@ -64,16 +67,31 @@ jobs:
         with:
           detached: true
 
+      - name: Install yq
+        run: sudo snap install yq
       - name: Setup LXD
         uses: canonical/setup-lxd@main
 
       - name: Install rockcraft
         run: sudo snap install rockcraft --classic --channel=latest/candidate
 
-      - name: Install goss
-      #   run: curl -fsSL https://goss.rocks/install | sh
+      # Gatekeeper step: verifying if this specific version folder targets this CPU architecture
+      - name: Check architecture compatibility
+        id: check-arch
         run: |
-          uname -a
+          cd "${{ matrix.version }}"
+          if ! rockcraft expand-extensions | yq '.platforms | keys | .[]' | grep -q "^${{ matrix.platform.arch }}$"; then
+            echo "supported=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ${{ matrix.platform.arch }} for version ${{ matrix.version }} (not supported after evaluation)"
+          else
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install goss
+        if: steps.check-arch.outputs.supported == 'true'
+        run: |
+          # this is the same script as in https://goss.rocks/install
+          # with the arch updated to "$(uname -m)" when it is not arm/arm64/amd64.
           LATEST_URL="https://github.com/goss-org/goss/releases/latest"
           LATEST_EFFECTIVE=$(curl -s -L -o /dev/null ${LATEST_URL} -w '%{url_effective}')
           LATEST=${LATEST_EFFECTIVE##*/}
@@ -120,6 +138,7 @@ jobs:
           echo "dgoss $DGOSS_VER has been installed to $DGOSS_INSTALL_LOC"
 
       - name: Pack and test rocks
-        run: |
+        if: steps.check-arch.outputs.supported == 'true'
+        run:
           GOSS_FILES_PATH="$GITHUB_WORKSPACE" \
-            ./scripts/pack-and-test.sh ${{ needs.detect-changes.outputs.versions }}
+            ./scripts/pack-and-test.sh ${{ matrix.version }}

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           sudo snap install rockcraft --classic  --channel=latest/candidate
           # Install goss for testing
-          curl -fsSL https://goss.rocks/install | sh
+          ./scripts/install-goss.sh
 
       - name: Pack, test and push rocks
         env:

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Determine modified rocks
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.changed-versions.outputs.versions }}
+      versions: ${{ steps.format-json.outputs.versions }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,37 +36,106 @@ jobs:
           changed_files=$(git diff --name-only origin/main..HEAD -- '**/rockcraft.yaml' '**/files/**' || true)
           ./scripts/extract-versions.sh $changed_files
 
-  build-and-publish:
-    name: Pack, test and publish
-    runs-on: ubuntu-latest
+      - name: Format versions as JSON array
+        id: format-json
+        env:
+          RAW_VERSIONS: ${{ steps.changed-versions.outputs.versions }}
+        run: |
+          if [ -z "$RAW_VERSIONS" ]; then
+            echo "versions=[]" >> "$GITHUB_OUTPUT"
+          else
+            JSON_ARRAY=$(echo "$RAW_VERSIONS" | xargs jq -n -c '$ARGS.positional' --args)
+            echo "versions=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-test:
+    name: Pack and test ${{ matrix.version }} on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runner-labels }}
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.versions != ''
+    if: needs.detect-changes.outputs.versions != '' && needs.detect-changes.outputs.versions != '[]'
+    strategy:
+      fail-fast: true
+      matrix:
+        version: ${{ fromJson(needs.detect-changes.outputs.versions) }}
+        platform:
+          - name: amd64
+            arch: amd64
+            runner-labels: [ubuntu-latest]
+          - name: arm64
+            arch: arm64
+            runner-labels: [ubuntu-24.04-arm]
+          - name: s390x
+            arch: s390x
+            runner-labels: [self-hosted-linux-s390x-noble-medium]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
 
+      - name: Install yq
+        run: sudo snap install yq
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
 
-      - name: Install dependencies
-        run: |
-          sudo snap install rockcraft --classic  --channel=latest/candidate
-          # Install goss for testing
-          ./scripts/install-goss.sh
+      - name: Install rockcraft
+        run: sudo snap install rockcraft --classic --channel=latest/candidate
 
-      - name: Pack, test and push rocks
+      - name: Check architecture compatibility
+        id: check-arch
+        run: |
+          cd "${{ matrix.version }}"
+          if ! rockcraft expand-extensions | yq '.platforms | keys | .[]' | grep -q "^${{ matrix.platform.arch }}$"; then
+            echo "supported=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ${{ matrix.platform.arch }} for version ${{ matrix.version }} (not supported after evaluation)"
+          else
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install goss
+        if: steps.check-arch.outputs.supported == 'true'
+        run: ./scripts/install-goss.sh
+
+      - name: Pack and test rock
+        if: steps.check-arch.outputs.supported == 'true'
         env:
           GOSS_FILES_PATH: ${{ github.workspace }}
-        run: |
-          ./scripts/pack-and-test.sh ${{ needs.detect-changes.outputs.versions }}
+        run: ./scripts/pack-and-test.sh ${{ matrix.version }}
 
-          # Push each rock to GHCR
-          for version in ${{ needs.detect-changes.outputs.versions }}; do
-            rock_file=$(ls "$version"/*.rock)
-            sudo rockcraft.skopeo --insecure-policy copy \
-              "oci-archive:$rock_file" \
-              "docker://ghcr.io/canonical/traefik:dev" \
-              --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
+      - name: Upload rock artifact
+        if: steps.check-arch.outputs.supported == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rock-${{ matrix.version }}-${{ matrix.platform.arch }}
+          path: ${{ matrix.version }}/*.rock
+          if-no-files-found: error
+
+  assemble-and-publish:
+    name: Assemble and publish ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-and-test]
+    if: needs.detect-changes.outputs.versions != '' && needs.detect-changes.outputs.versions != '[]'
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.detect-changes.outputs.versions) }}
+    steps:
+      - name: Download all rock artifacts for ${{ matrix.version }}
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rock-${{ matrix.version }}-*
+          merge-multiple: true
+          path: rocks/
+
+      - name: Install buildah
+        run: sudo apt-get update && sudo apt-get install -y buildah
+
+      - name: Assemble multi-arch manifest and push to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | buildah login ghcr.io -u "${{ github.actor }}" --password-stdin
+          buildah manifest create multi-arch-rock
+          for rock in rocks/*.rock; do
+            buildah manifest add multi-arch-rock "oci-archive:$rock"
           done
+          buildah manifest push --format oci --all multi-arch-rock \
+            "docker://ghcr.io/canonical/traefik:dev"

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -24,7 +24,7 @@ jobs:
         env:
           VERSIONS: ${{ inputs.versions }}
         run: |
-          JSON_ARRAY=$(echo "$VERSIONS" | tr ',' '\n' | jq -R . | jq -c -s .)
+          JSON_ARRAY=$(echo "$VERSIONS" | tr ',' '\n' | jq -R 'gsub("^\\s+|\\s+$"; "")' | jq -c -s 'map(select(length>0))')
           echo "versions=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
 
   build-and-test:

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo snap install rockcraft --classic  --channel=latest/candidate
           sudo snap install yq
-          curl -fsSL https://goss.rocks/install | sh
+          ./rock/scripts/install-goss.sh
 
       - name: Pack and test rocks
         run: |

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -13,32 +13,86 @@ on:
         type: string
 
 jobs:
-  build-and-release:
-    name: Pack, test and release to OCI Factory
+  prepare:
+    name: Prepare versions
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.format-json.outputs.versions }}
+    steps:
+      - name: Format versions as JSON array
+        id: format-json
+        env:
+          VERSIONS: ${{ inputs.versions }}
+        run: |
+          JSON_ARRAY=$(echo "$VERSIONS" | tr ',' '\n' | jq -R . | jq -c -s .)
+          echo "versions=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
+
+  build-and-test:
+    name: Pack and test ${{ matrix.version }} on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runner-labels }}
+    needs: [prepare]
+    strategy:
+      fail-fast: true
+      matrix:
+        version: ${{ fromJson(needs.prepare.outputs.versions) }}
+        platform:
+          - name: amd64
+            arch: amd64
+            runner-labels: [ubuntu-latest]
+          - name: arm64
+            arch: arm64
+            runner-labels: [ubuntu-24.04-arm]
+          - name: s390x
+            arch: s390x
+            runner-labels: [self-hosted-linux-s390x-noble-medium]
     steps:
       - name: Checkout the rock repository
         uses: actions/checkout@v4
         with:
           path: rock
 
+      - name: Install yq
+        run: sudo snap install yq
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
 
-      - name: Install dependencies
-        run: |
-          sudo snap install rockcraft --classic  --channel=latest/candidate
-          sudo snap install yq
-          ./rock/scripts/install-goss.sh
+      - name: Install rockcraft
+        run: sudo snap install rockcraft --classic --channel=latest/candidate
 
-      - name: Pack and test rocks
+      - name: Check architecture compatibility
+        id: check-arch
+        run: |
+          cd "rock/${{ matrix.version }}"
+          if ! rockcraft expand-extensions | yq '.platforms | keys | .[]' | grep -q "^${{ matrix.platform.arch }}$"; then
+            echo "supported=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ${{ matrix.platform.arch }} for version ${{ matrix.version }} (not supported after evaluation)"
+          else
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install goss
+        if: steps.check-arch.outputs.supported == 'true'
+        run: ./rock/scripts/install-goss.sh
+
+      - name: Pack and test rock
+        if: steps.check-arch.outputs.supported == 'true'
+        env:
+          GOSS_FILES_PATH: ${{ github.workspace }}/rock
         run: |
           cd rock
-          versions="${VERSIONS//,/ }"
-          GOSS_FILES_PATH="$GITHUB_WORKSPACE/rock" \
-            ./scripts/pack-and-test.sh $versions
-        env:
-          VERSIONS: ${{ inputs.versions }}
+          ./scripts/pack-and-test.sh ${{ matrix.version }}
+
+  release:
+    name: Open PR to OCI Factory
+    runs-on: ubuntu-latest
+    needs: [prepare, build-and-test]
+    if: needs.prepare.outputs.versions != '[]'
+    steps:
+      - name: Checkout the rock repository
+        uses: actions/checkout@v4
+        with:
+          path: rock
 
       - name: Fork sync and clone OCI Factory
         env:

--- a/2.11.46/rockcraft.yaml
+++ b/2.11.46/rockcraft.yaml
@@ -32,14 +32,19 @@ parts:
     build-snaps:
       - node/22/stable
     override-build: |
-      npm install -g yarn && \
-      cd ./webui && \
+      npm install -g yarn
+      cd ./webui
       # added --legacy-peer-deps to avoid dependency resolution errors with mocha (testing)
-      npm install --legacy-peer-deps --ignore-scripts && \
-      export PATH="$PWD/node_modules/.bin:$PATH" && \
+      if [ "$CRAFT_TARGET_ARCH" = "s390x" ]; then
+        npm install sass --save-dev
+        npm install --legacy-peer-deps --ignore-scripts --overrides='{"sass-embedded": "$sass"}'
+      else
+        npm install --legacy-peer-deps --ignore-scripts
+      fi
+      export PATH="$PWD/node_modules/.bin:$PATH"
       # Build the bundle as per:
       # https://github.com/traefik/traefik/blob/84a081054688349fa4e2513599e3bf2395331492/Makefile#L66
-      npm run build:nc && \
+      npm run build:nc
       # cleanup
       rm -rf node_modules
   default-config:

--- a/2.11.46/rockcraft.yaml
+++ b/2.11.46/rockcraft.yaml
@@ -20,6 +20,8 @@ services:
     startup: enabled
 platforms:
   amd64:
+  s390x:
+  arm64:
 parts:
   traefik-frontend:
     plugin: nil

--- a/2.11.46/rockcraft.yaml
+++ b/2.11.46/rockcraft.yaml
@@ -34,13 +34,14 @@ parts:
     override-build: |
       npm install -g yarn
       cd ./webui
-      # added --legacy-peer-deps to avoid dependency resolution errors with mocha (testing)
-      if [ "$CRAFT_TARGET_ARCH" = "s390x" ]; then
-        npm install sass --save-dev
-        npm install --legacy-peer-deps --ignore-scripts --overrides='{"sass-embedded": "$sass"}'
-      else
-        npm install --legacy-peer-deps --ignore-scripts
+      # Fix for s390x: Force npm & yarn to intercept deep sass-embedded packages
+      # and replace them globally with the pure JavaScript sass engine
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "s390x" ]; then
+        npm pkg set overrides.sass-embedded="npm:sass@^1.70.0"
+        npm pkg set resolutions.sass-embedded="npm:sass@^1.70.0"
       fi
+      # added --legacy-peer-deps to avoid dependency resolution errors with mocha (testing)
+      npm install --legacy-peer-deps --ignore-scripts
       export PATH="$PWD/node_modules/.bin:$PATH"
       # Build the bundle as per:
       # https://github.com/traefik/traefik/blob/84a081054688349fa4e2513599e3bf2395331492/Makefile#L66

--- a/scripts/install-goss.sh
+++ b/scripts/install-goss.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Installs goss and dgoss to GOSS_DST (default: /usr/local/bin).
+#
+# This is a modified version of the official https://goss.rocks/install script.
+# The main change is the arch detection logic: the official script only handles
+# amd64 and arm64, so it falls back to the raw `uname -m` output for other arches
+# (e.g. s390x). This is intentional — goss release assets use the kernel's own
+# naming for non-x86/arm platforms.
+# See: https://github.com/goss-org/goss/issues/1065
+
+LATEST_URL="https://github.com/goss-org/goss/releases/latest"
+LATEST_EFFECTIVE=$(curl -s -L -o /dev/null "${LATEST_URL}" -w '%{url_effective}')
+LATEST="${LATEST_EFFECTIVE##*/}"
+
+DGOSS_VER="${GOSS_VER:-}"
+
+if [ -z "${GOSS_VER:-}" ]; then
+    GOSS_VER="${LATEST}"
+    DGOSS_VER="master"
+fi
+if [ -z "${GOSS_VER}" ]; then
+    echo "ERROR: Could not automatically detect latest version, set GOSS_VER env var and re-run"
+    exit 1
+fi
+
+GOSS_DST="${GOSS_DST:-/usr/local/bin}"
+INSTALL_LOC="${GOSS_DST%/}/goss"
+DGOSS_INSTALL_LOC="${GOSS_DST%/}/dgoss"
+
+touch "${INSTALL_LOC}" || { echo "ERROR: Cannot write to ${GOSS_DST}; set GOSS_DST elsewhere or use sudo"; exit 1; }
+
+arch=""
+case "$(uname -m)" in
+    x86_64)          arch="amd64" ;;
+    aarch32)         arch="arm" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *)               arch="$(uname -m)" ;;
+esac
+
+url="https://github.com/goss-org/goss/releases/download/${GOSS_VER}/goss-linux-${arch}"
+echo "Downloading ${url}"
+curl -fsSL "${url}" -o "${INSTALL_LOC}"
+chmod +rx "${INSTALL_LOC}"
+echo "goss ${GOSS_VER} installed to ${INSTALL_LOC}"
+"${INSTALL_LOC}" --version
+
+dgoss_url="https://raw.githubusercontent.com/goss-org/goss/${DGOSS_VER}/extras/dgoss/dgoss"
+echo "Downloading ${dgoss_url}"
+curl -fsSL "${dgoss_url}" -o "${DGOSS_INSTALL_LOC}"
+chmod +rx "${DGOSS_INSTALL_LOC}"
+echo "dgoss ${DGOSS_VER} installed to ${DGOSS_INSTALL_LOC}"


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Add s390x and arm64 architectures for Traefik.

This is a requirement from customers for s390x. For arm64 that is a practice I will be adding to all our charms.

## Solution
<!-- A summary of the solution addressing the above issue -->

Not there are two dimensions in the rocks, the architectures and the versions for them, which makes the pipelines more complex.

Now all the rocks are multi-arch, and buildah is used for creating the multi-arch image, similar as how it is done in oci-factory. 

For the new s390x, there is an issue in the installation for goss (see https://github.com/goss-org/goss/issues/1065). As a workaround the installation script was copied to this repo adapted to work with s390x. 



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
